### PR TITLE
Fix(parser): Handle duplicate keys in AndroidXMLParser

### DIFF
--- a/parsers/android_xml_parser.py
+++ b/parsers/android_xml_parser.py
@@ -117,10 +117,17 @@ class AndroidXMLParser(TranslationParser):
                     
                     value = self._parse_android_text(element)
 
-                    if key in translations:
-                        msg = f"Duplicate string key '{key}' found ({current_item_ref}). Value will be overwritten."
+                    original_key = key
+                    counter = 1
+                    while key in translations:
+                        key = f"{original_key}_{counter}"
+                        counter += 1
+
+                    if key != original_key:
+                        msg = f"Duplicate string key '{original_key}' found ({current_item_ref}). Renamed to '{key}'."
                         logger.warning(msg)
                         parsing_errors.append(msg)
+
                     translations[key] = value
                     line_numbers[key] = processed_elements_count # Approximate order/pseudo-line number
                         
@@ -143,10 +150,18 @@ class AndroidXMLParser(TranslationParser):
                             logger.warning(msg)
                             parsing_errors.append(msg)
                     if current_plurals:
-                        if key in plurals:
-                           msg = f"Duplicate plurals key '{key}' found ({current_item_ref}). Will be overwritten."
-                           logger.warning(msg)
-                           parsing_errors.append(msg)
+                        original_key = key
+                        counter = 1
+                        # Check for duplicates in plurals dict and also in line_numbers to avoid collision with renamed string keys
+                        while key in plurals or f"plurals_{key}" in line_numbers:
+                            key = f"{original_key}_{counter}"
+                            counter += 1
+
+                        if key != original_key:
+                            msg = f"Duplicate plurals key '{original_key}' found ({current_item_ref}). Renamed to '{key}'."
+                            logger.warning(msg)
+                            parsing_errors.append(msg)
+
                         plurals[key] = current_plurals
                         # Also add to line_numbers for plurals parent
                         line_numbers[f"plurals_{key}"] = processed_elements_count
@@ -165,10 +180,18 @@ class AndroidXMLParser(TranslationParser):
                         current_array_items.append(item_value)
 
                     if current_array_items:
-                        if key in string_arrays:
-                           msg = f"Duplicate string-array key '{key}' found ({current_item_ref}). Will be overwritten."
-                           logger.warning(msg)
-                           parsing_errors.append(msg)
+                        original_key = key
+                        counter = 1
+                        # Check for duplicates in string_arrays dict and also in line_numbers to avoid collision
+                        while key in string_arrays or f"string-array_{key}" in line_numbers:
+                            key = f"{original_key}_{counter}"
+                            counter += 1
+
+                        if key != original_key:
+                            msg = f"Duplicate string-array key '{original_key}' found ({current_item_ref}). Renamed to '{key}'."
+                            logger.warning(msg)
+                            parsing_errors.append(msg)
+
                         string_arrays[key] = current_array_items
                         # Also add to line_numbers for string-array parent
                         line_numbers[f"string-array_{key}"] = processed_elements_count

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,6 +4,8 @@ import yaml
 from parsers.json_parser import JSONParser
 from parsers.yaml_parser import YAMLParser
 from parsers.lang_parser import LangParser
+from parsers.android_xml_parser import AndroidXMLParser
+from core.parsing_result import ParsingResult
 
 # JSON Parser Tests
 def test_json_parser_valid():
@@ -79,3 +81,109 @@ def test_lang_parser_no_trim():
     content = "  key  =  value  "
     result = parser.parse(content)
     assert result == {"  key  ": "  value  "}
+
+# Android XML Parser Tests
+def test_android_xml_parser_duplicate_keys():
+    """
+    Tests AndroidXMLParser's handling of duplicate keys for strings, plurals, and string-arrays.
+    """
+    parser = AndroidXMLParser()
+    xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Strings -->
+    <string name="app_name">My App</string>
+    <string name="app_name">My App V2</string> <!-- Duplicate -->
+    <string name="unique_string">Unique Value</string>
+
+    <!-- Plurals -->
+    <plurals name="item_count">
+        <item quantity="one">1 item</item>
+        <item quantity="other">%d items</item>
+    </plurals>
+    <plurals name="item_count"> <!-- Duplicate -->
+        <item quantity="one">One item</item>
+        <item quantity="other">Many items</item>
+    </plurals>
+    <plurals name="unique_plural">
+        <item quantity="one">1 unique plural</item>
+        <item quantity="other">%d unique plurals</item>
+    </plurals>
+
+    <!-- String Arrays -->
+    <string-array name="options_menu">
+        <item>Settings</item>
+        <item>Help</item>
+    </string-array>
+    <string-array name="options_menu"> <!-- Duplicate -->
+        <item>Profile</item>
+        <item>Logout</item>
+    </string-array>
+    <string-array name="unique_array">
+        <item>Unique Item 1</item>
+        <item>Unique Item 2</item>
+    </string-array>
+</resources>
+    """
+    result: ParsingResult = parser.parse(xml_content)
+
+    # Assertions for Translations (Strings)
+    assert "app_name" in result.translations
+    assert result.translations["app_name"] == "My App"
+    assert "app_name_1" in result.translations
+    assert result.translations["app_name_1"] == "My App V2"
+    assert "unique_string" in result.translations
+    assert result.translations["unique_string"] == "Unique Value"
+
+    # Assertions for Metadata (Plurals)
+    assert result.metadata is not None
+    assert "plurals" in result.metadata
+    plurals_data = result.metadata["plurals"]
+
+    assert "item_count" in plurals_data
+    assert plurals_data["item_count"] == {"one": "1 item", "other": "%d items"}
+    assert "item_count_1" in plurals_data
+    assert plurals_data["item_count_1"] == {"one": "One item", "other": "Many items"}
+    assert "unique_plural" in plurals_data
+    assert plurals_data["unique_plural"] == {"one": "1 unique plural", "other": "%d unique plurals"}
+
+    # Assertions for Metadata (String Arrays)
+    assert "string_arrays" in result.metadata
+    string_arrays_data = result.metadata["string_arrays"]
+
+    assert "options_menu" in string_arrays_data
+    assert string_arrays_data["options_menu"] == ["Settings", "Help"]
+    assert "options_menu_1" in string_arrays_data
+    assert string_arrays_data["options_menu_1"] == ["Profile", "Logout"]
+    assert "unique_array" in string_arrays_data
+    assert string_arrays_data["unique_array"] == ["Unique Item 1", "Unique Item 2"]
+
+    # Assertions for Errors/Warnings
+    assert result.errors is not None
+    assert len(result.errors) == 3 # Expecting 3 warnings for the 3 duplicate keys
+
+    # Check for specific warning messages (content may vary slightly based on approx. item number)
+    # We'll check for the core part of the message.
+    app_name_warning_found = any("Duplicate string key 'app_name' found" in error and "Renamed to 'app_name_1'" in error for error in result.errors)
+    item_count_warning_found = any("Duplicate plurals key 'item_count' found" in error and "Renamed to 'item_count_1'" in error for error in result.errors)
+    options_menu_warning_found = any("Duplicate string-array key 'options_menu' found" in error and "Renamed to 'options_menu_1'" in error for error in result.errors)
+
+    assert app_name_warning_found, "Warning for app_name duplication not found."
+    assert item_count_warning_found, "Warning for item_count duplication not found."
+    assert options_menu_warning_found, "Warning for options_menu duplication not found."
+
+    # Assertions for Line Numbers
+    assert result.line_numbers is not None
+    # String line numbers (exact numbers depend on XML structure and parser's counting)
+    assert "app_name" in result.line_numbers
+    assert "app_name_1" in result.line_numbers
+    assert "unique_string" in result.line_numbers
+
+    # Plurals line numbers
+    assert "plurals_item_count" in result.line_numbers
+    assert "plurals_item_count_1" in result.line_numbers
+    assert "plurals_unique_plural" in result.line_numbers
+
+    # String-array line numbers
+    assert "string-array_options_menu" in result.line_numbers
+    assert "string-array_options_menu_1" in result.line_numbers
+    assert "string-array_unique_array" in result.line_numbers


### PR DESCRIPTION
The AndroidXMLParser previously overwrote values when duplicate keys (e.g., multiple <string name="foo"> entries) were encountered in an Android XML file. This could lead to data loss and parsing errors downstream.

This commit modifies the AndroidXMLParser to:
- Detect duplicate keys for <string>, <plurals>, and <string-array> elements.
- Rename duplicate keys by appending a numerical suffix (e.g., 'foo', 'foo_1', 'foo_2').
- Add a warning to the ParsingResult.errors list for each renamed key, informing you of the original name and the new name.
- Ensure that line_numbers and metadata (for plurals and string-arrays) also reflect these renamed keys.

A new unit test, test_android_xml_parser_duplicate_keys, has been added to verify this behavior. This test confirms that all data is preserved, keys are correctly renamed, and appropriate warnings are generated.

This change should resolve issues where parsing would appear to fail or produce incomplete results when processing Android XML files with duplicate resource names.