### PR TITLE
Refactor(parser): Differentiate warnings and errors in ParsingResult

### DIFF
--- a/core/parsing_result.py
+++ b/core/parsing_result.py
@@ -8,7 +8,8 @@ class ParsingResult:
                  translations: Dict[str, str],
                  line_numbers: Optional[Dict[str, int]] = None,
                  metadata: Optional[Dict[str, Any]] = None,
-                 errors: Optional[List[str]] = None):
+                 errors: Optional[List[str]] = None,
+                 warnings: Optional[List[str]] = None):
         """
         Initializes the ParsingResult.
 
@@ -17,18 +18,21 @@ class ParsingResult:
             line_numbers: An optional dictionary mapping translation keys to their line numbers in the source file.
             metadata: An optional dictionary for any other parser-specific metadata
                       (e.g., plurals, comments, language codes).
-            errors: An optional list of non-critical error or warning messages encountered during parsing.
+            errors: An optional list of critical error messages encountered during parsing.
+            warnings: An optional list of non-critical warning messages encountered during parsing.
         """
         self.translations: Dict[str, str] = translations
         self.line_numbers: Optional[Dict[str, int]] = line_numbers if line_numbers is not None else {}
         self.metadata: Optional[Dict[str, Any]] = metadata if metadata is not None else {}
         self.errors: Optional[List[str]] = errors if errors is not None else []
+        self.warnings: Optional[List[str]] = warnings if warnings is not None else []
 
     def __repr__(self) -> str:
         return (f"ParsingResult(translations_count={len(self.translations)}, "
                 f"has_line_numbers={bool(self.line_numbers)}, "
                 f"metadata_keys={list(self.metadata.keys()) if self.metadata else []}, "
-                f"errors_count={len(self.errors)})")
+                f"errors_count={len(self.errors)}, "
+                f"warnings_count={len(self.warnings)})")
 
     def __bool__(self) -> bool:
         """

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,6 +4,8 @@ import yaml
 from parsers.json_parser import JSONParser
 from parsers.yaml_parser import YAMLParser
 from parsers.lang_parser import LangParser
+from parsers.android_xml_parser import AndroidXMLParser
+from core.parsing_result import ParsingResult
 
 # JSON Parser Tests
 def test_json_parser_valid():
@@ -79,3 +81,165 @@ def test_lang_parser_no_trim():
     content = "  key  =  value  "
     result = parser.parse(content)
     assert result == {"  key  ": "  value  "}
+
+# Android XML Parser Tests
+def test_android_xml_parser_duplicate_keys():
+    """
+    Tests AndroidXMLParser's handling of duplicate keys for strings, plurals, and string-arrays.
+    """
+    parser = AndroidXMLParser()
+    xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Strings -->
+    <string name="app_name">My App</string>
+    <string name="app_name">My App V2</string> <!-- Duplicate -->
+    <string name="unique_string">Unique Value</string>
+
+    <!-- Plurals -->
+    <plurals name="item_count">
+        <item quantity="one">1 item</item>
+        <item quantity="other">%d items</item>
+    </plurals>
+    <plurals name="item_count"> <!-- Duplicate -->
+        <item quantity="one">One item</item>
+        <item quantity="other">Many items</item>
+    </plurals>
+    <plurals name="unique_plural">
+        <item quantity="one">1 unique plural</item>
+        <item quantity="other">%d unique plurals</item>
+    </plurals>
+
+    <!-- String Arrays -->
+    <string-array name="options_menu">
+        <item>Settings</item>
+        <item>Help</item>
+    </string-array>
+    <string-array name="options_menu"> <!-- Duplicate -->
+        <item>Profile</item>
+        <item>Logout</item>
+    </string-array>
+    <string-array name="unique_array">
+        <item>Unique Item 1</item>
+        <item>Unique Item 2</item>
+    </string-array>
+</resources>
+    """
+    result: ParsingResult = parser.parse(xml_content)
+
+    # Assertions for Translations (Strings)
+    assert "app_name" in result.translations
+    assert result.translations["app_name"] == "My App"
+    assert "app_name_1" in result.translations
+    assert result.translations["app_name_1"] == "My App V2"
+    assert "unique_string" in result.translations
+    assert result.translations["unique_string"] == "Unique Value"
+
+    # Assertions for Metadata (Plurals)
+    assert result.metadata is not None
+    assert "plurals" in result.metadata
+    plurals_data = result.metadata["plurals"]
+
+    assert "item_count" in plurals_data
+    assert plurals_data["item_count"] == {"one": "1 item", "other": "%d items"}
+    assert "item_count_1" in plurals_data
+    assert plurals_data["item_count_1"] == {"one": "One item", "other": "Many items"}
+    assert "unique_plural" in plurals_data
+    assert plurals_data["unique_plural"] == {"one": "1 unique plural", "other": "%d unique plurals"}
+
+    # Assertions for Metadata (String Arrays)
+    assert "string_arrays" in result.metadata
+    string_arrays_data = result.metadata["string_arrays"]
+
+    assert "options_menu" in string_arrays_data
+    assert string_arrays_data["options_menu"] == ["Settings", "Help"]
+    assert "options_menu_1" in string_arrays_data
+    assert string_arrays_data["options_menu_1"] == ["Profile", "Logout"]
+    assert "unique_array" in string_arrays_data
+    assert string_arrays_data["unique_array"] == ["Unique Item 1", "Unique Item 2"]
+
+    # Assertions for Errors/Warnings
+    assert result.warnings is not None
+    assert len(result.warnings) == 3 # Expecting 3 warnings for the 3 duplicate keys
+    assert result.errors is not None
+    assert len(result.errors) == 0 # Expecting 0 critical errors for this test case
+
+    # Check for specific warning messages (content may vary slightly based on approx. item number)
+    # We'll check for the core part of the message in warnings.
+    app_name_warning_found = any("Duplicate string key 'app_name' found" in warning and "Renamed to 'app_name_1'" in warning for warning in result.warnings)
+    item_count_warning_found = any("Duplicate plurals key 'item_count' found" in warning and "Renamed to 'item_count_1'" in warning for warning in result.warnings)
+    options_menu_warning_found = any("Duplicate string-array key 'options_menu' found" in warning and "Renamed to 'options_menu_1'" in warning for warning in result.warnings)
+
+    assert app_name_warning_found, "Warning for app_name duplication not found in result.warnings."
+    assert item_count_warning_found, "Warning for item_count duplication not found in result.warnings."
+    assert options_menu_warning_found, "Warning for options_menu duplication not found in result.warnings."
+
+    # Assertions for Line Numbers
+    assert result.line_numbers is not None
+    # String line numbers (exact numbers depend on XML structure and parser's counting)
+    assert "app_name" in result.line_numbers
+    assert "app_name_1" in result.line_numbers
+    assert "unique_string" in result.line_numbers
+
+    # Plurals line numbers
+    assert "plurals_item_count" in result.line_numbers
+    assert "plurals_item_count_1" in result.line_numbers
+    assert "plurals_unique_plural" in result.line_numbers
+
+    # String-array line numbers
+    assert "string-array_options_menu" in result.line_numbers
+    assert "string-array_options_menu_1" in result.line_numbers
+    assert "string-array_unique_array" in result.line_numbers
+
+def test_android_xml_parser_problematic_key_name():
+    """
+    Tests AndroidXMLParser's handling of string keys with names like "<string id".
+    """
+    parser = AndroidXMLParser()
+    xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="normal_key">Normal Value</string>
+    <string name="&lt;string id">Value 1</string> <!-- XML escaped problematic key -->
+    <string name="&lt;string id">Value 2</string> <!-- Duplicate problematic key -->
+</resources>
+    """
+    # Note: In the XML, the problematic key "<string id" must be XML escaped as "&lt;string id"
+    # to be valid XML. ElementTree will unescape it during parsing, so the key in translations
+    # will be "<string id".
+
+    result: ParsingResult = parser.parse(xml_content)
+
+    problematic_key_original = "<string id"
+    problematic_key_renamed = "<string id_1"
+
+    # Assertions for Translations (Strings)
+    assert "normal_key" in result.translations
+    assert result.translations["normal_key"] == "Normal Value"
+
+    assert problematic_key_original in result.translations
+    assert result.translations[problematic_key_original] == "Value 1"
+
+    assert problematic_key_renamed in result.translations
+    assert result.translations[problematic_key_renamed] == "Value 2"
+
+    # Assertions for Warnings
+    assert result.warnings is not None
+    assert len(result.warnings) == 1 # Expecting 1 warning for the duplicate problematic key
+
+    expected_warning_msg_part_orig = f"Duplicate string key '{problematic_key_original}' found"
+    expected_warning_msg_part_renamed = f"Renamed to '{problematic_key_renamed}'"
+
+    warning_found = any(
+        expected_warning_msg_part_orig in warning and expected_warning_msg_part_renamed in warning
+        for warning in result.warnings
+    )
+    assert warning_found, f"Warning for duplicated problematic key '{problematic_key_original}' not found in result.warnings."
+
+    # Assertions for Errors
+    assert result.errors is not None
+    assert len(result.errors) == 0 # Expecting 0 critical errors
+
+    # Assertions for Line Numbers
+    assert result.line_numbers is not None
+    assert "normal_key" in result.line_numbers
+    assert problematic_key_original in result.line_numbers
+    assert problematic_key_renamed in result.line_numbers


### PR DESCRIPTION
This commit introduces a distinction between critical errors and non-critical warnings in the parsing process.

Modifications:
- `core/parsing_result.py`:
  - Added an optional `warnings: List[str]` field to `ParsingResult`. Critical issues go into `errors`, while informational messages (like key renames) go into `warnings`.

- `parsers/android_xml_parser.py`:
  - Updated to populate `ParsingResult.warnings` with messages about renamed duplicate keys for <string>, <plurals>, and <string-array> elements.
  - Critical issues like missing 'name' attributes or XML syntax errors continue to populate `ParsingResult.errors`.

- `GUI/flet_gui.py`:
  - Modified the `compare_files_gui` method to check `ParsingResult.errors` for critical failures. If errors are present, the comparison stops.
  - If only `ParsingResult.warnings` are present, these are logged (and can be displayed in the GUI status), but the comparison process continues. This prevents non-critical issues like key renames from halting the application.

- `tests/test_parsers.py`:
  - Updated `test_android_xml_parser_duplicate_keys` to reflect that renaming messages now appear in `result.warnings`.
  - Added `test_android_xml_parser_problematic_key_name` to ensure correct handling and renaming of keys with XML-like literal names (e.g., name="<string id>").

This resolves an issue where duplicate key warnings from the AndroidXMLParser were treated as fatal errors by the GUI, preventing comparisons. The system is now more resilient to non-critical issues in input files.